### PR TITLE
Bugfix + Duplicate Variable

### DIFF
--- a/Fallout_Shelter.py
+++ b/Fallout_Shelter.py
@@ -1827,6 +1827,7 @@ def game():
     global end
     global postition
     global people
+    global day_count
     global inventory
     global rooms
     global caps
@@ -1907,9 +1908,9 @@ def game():
     # Can be set to 0 by player to conserve food.  Recomended to only do so
     # during food emergencies.
     auto_feed = 1
-    # Keeps track whether or not player has used too many Action points for a
-    # day.
-    overuse = 0
+		# Keeps track whether or not player has used too many Action points for a
+		# day.
+		# overuse = 0    Why is this declared twice?
 
     print("Welcome to the text-based fallout shelter game!")
     print("Welcome, great Overseer!")


### PR DESCRIPTION
day_count is called when creating a player, but no variable is defined
in scope.  Declared global as a quick fix.

overuse = 0 is declared twice...Is this a typo or simply a duplicate?  I commented the second declaration out.
